### PR TITLE
Update node-expat dependency for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "node" : ">=0.6.11"
   },
   "dependencies": {
-    "node-expat": "1.4.x"
+    "node-expat": "2.0.x"
   }
 }


### PR DESCRIPTION
node-expat began using node-gyp over node-waf around version 1.6.1 or 2.0.0. node-waf is not and will not be compatible with Windows from what I've read. I've tested mediainfo with 2.0.0 and all is well so far.
