### PR TITLE
Node 0.12 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.idea

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "node-expat": "2.3.x",
-    "filesize-parser": "~0.0.2"
+    "filesize-parser": "~1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=0.6.11"
   },
   "dependencies": {
-    "node-expat": "2.0.x",
+    "node-expat": "2.3.x",
     "filesize-parser": "~0.0.2"
   }
 }


### PR DESCRIPTION
Bumped version of `node-expat` in order to get ability to build under Node 0.12.
