### PR TITLE
bumped node-expat and filesize-parser versions 

### DIFF
--- a/lib/mediainfo.js
+++ b/lib/mediainfo.js
@@ -7,7 +7,7 @@ module.exports = function() {
 
   var done = files.pop();
 
-  child_process.execFile("mediainfo", ["--Output=XML"].concat(files), function(err, stdout, stderr) {
+  child_process.execFile("mediainfo", ["--inform=OLDXML"].concat(files), function(err, stdout, stderr) {
     if (err) {
       return done(err);
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=0.6.11"
   },
   "dependencies": {
-    "node-expat": "2.0.x",
-    "filesize-parser": "~0.0.2"
+    "node-expat": "^2.1.4",
+    "filesize-parser": "^1.3.0"
   }
 }


### PR DESCRIPTION
node-expat 2.1.4 solves many install problems -> I was unable to install on Linux and Mac with previous version both with node 4.2.6 and 5.5.0.

As for filesize-parser, version was really old and the 1.3.0 is perfectly compatible.
